### PR TITLE
Lock in a transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers
+transformers==4.33.0
 accelerate~=0.21.0
 sentencepiece~=0.1.99
 fastapi~=0.100.0


### PR DESCRIPTION
This will fix the following issue. 

```
ImportError: cannot import name '_expand_mask' from 'transformers.models.bloom.modeling_bloom' (/home/vladimir/Documents/function-calling-server/myenv/lib/python3.10/site-packages/transformers/models/bloom/modeling_bloom.py)
```